### PR TITLE
Changes in the plugin to work with protractor 1.4

### DIFF
--- a/tasks/selenium_webdriver_phantom.js
+++ b/tasks/selenium_webdriver_phantom.js
@@ -200,7 +200,7 @@ module.exports = function(grunt) {
 
         // init options
         options = this.options({
-            path: require('path').resolve(protractor.path, 'selenium', 'selenium-server-standalone-' + protractor.package.webdriverVersions.selenium + '.jar'),
+            path: this.options().path || require('path').resolve(protractor.path, 'selenium', 'selenium-server-standalone-' + protractor.package.webdriverVersions.selenium + '.jar'),
 
             args: ['-Dwebdriver.chrome.driver=' + require('path').resolve(protractor.path, 'selenium', executableName('chromedriver'))]
         });


### PR DESCRIPTION
We have upgraded to protractor 1.4 and noticed that the plugin stopped working so we made a few changes to fix it:
- The new protractor does not have the property 'protractor.package.webdriverVersions.selenium' so the plugin wasn't able to find the selenium jar. To fix this we changed the code so you can pass the path to the jar as an option
- SeleniumServer is now outputting everything on the stderr so we modified the plugin to listen there instead of in the stdout.
